### PR TITLE
Fix missing logo in reserva page

### DIFF
--- a/reserva/index.html
+++ b/reserva/index.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 <body>
-  <img src="/img/logo.svg" alt="Diego Maury Logo" class="w-24 h-24 mb-4" />
+  <img src="/dmperfill.svg" alt="Diego Maury Logo" class="w-24 h-24 mb-4" />
   <h1 class="text-xl font-semibold mb-2">Un momento…</h1>
   <p class="mb-4">Te estoy redirigiendo a mi calendario en Notion para agendar una cita conmigo.</p>
   <p>Si no eres redirigido automáticamente, <a href="https://calendar.notion.so/meet/diegomaurymx/d73c14p5v" class="text-blue-500 underline">haz clic aquí</a>.</p>


### PR DESCRIPTION
## Summary
- point reserva page image to `/dmperfill.svg`

## Testing
- `npx postcss src/tailwind.css -o dist/tailwind.css`

------
https://chatgpt.com/codex/tasks/task_e_6882f642e750832184c15986ea258902