### PR TITLE
Add footer test with Jest

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
     <!-- Footer -->
     <footer class="bg-transparent w-full max-w-7xl mx-auto text-center py-4 mt-4 px-4">
         <p class="text-sm sm:text-base mb-2" style="color: #4b2672;">
-            Página hecha con mucho pasión y ChatGPT.
+            Página hecha con mucha pasión y ChatGPT.
         </p>
         <p class="text-xs sm:text-sm" style="color: #4b2672;">
             © <span id="currentYear"></span> DIEGO SONDHEIM LUPONE SAS. Todos los derechos reservados.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "scripts": {
-    "build:css": "postcss src/tailwind.css -o dist/tailwind.css"
+    "build:css": "postcss src/tailwind.css -o dist/tailwind.css",
+    "test": "jest"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^4.0.3",
     "postcss-cli": "^8.3.1",
     "tailwindcss": "^2.2.19",
-    "autoprefixer": "^10.4.0"
+    "autoprefixer": "^10.4.0",
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/footer.test.js
+++ b/tests/footer.test.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+test('footer contains "mucha pasión"', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const dom = new JSDOM(html);
+  const footerText = dom.window.document.querySelector('footer').textContent;
+  expect(footerText).toMatch(/mucha pasión/i);
+});


### PR DESCRIPTION
## Summary
- configure npm test script to run Jest
- add Jest and jsdom as dev dependencies
- create basic footer test
- fix footer text so test passes

## Testing
- `npm install --no-save jest jsdom` *(succeeds)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882f65490e0832186c60e5563bdbbb2